### PR TITLE
Patch 1

### DIFF
--- a/scibot/extract.py
+++ b/scibot/extract.py
@@ -340,6 +340,12 @@ def find_rrids(text):
     for prefix, a, b, nums, suffix in matches4:
         yield prefix, f'RRID:SAMN{nums.strip()}', f'{a}{b}{nums}', suffix
 
+    # fifth round for NCBI Taxonomy
+    regex5 = '(.{0,32})(NCBI)(((\s|:){0,2})((txid|Taxon)(_|:)?))([0-9]{3,8})([^\w].{0,31})'
+    matches5 = re.findall(regex5, text)
+    for prefix, ncbi, tax, nums, suffix in matches5:
+        yield prefix, f'RRID:NCBITaxon_{nums.strip()}', f'{a}{b}{nums}', suffix
+
 
 # extract from post
 

--- a/scibot/extract.py
+++ b/scibot/extract.py
@@ -341,10 +341,10 @@ def find_rrids(text):
         yield prefix, f'RRID:SAMN{nums.strip()}', f'{a}{b}{nums}', suffix
 
     # fifth round for NCBI Taxonomy
-    regex5 = '(.{0,32})(NCBI)(((\s|:){0,2})((txid|Taxon)(_|:)?))([0-9]{3,8})([^\w].{0,31})'
+    regex5 = '(.{0,32})(NCBI)(((:|(:\s))?)(((t|T)(a)?x((id)|(Id)|(ID))|Taxon)(_|:)?(\s)?))([0-9]{3,8})([^\w].{0,31})'
     matches5 = re.findall(regex5, text)
     for prefix, ncbi, tax, nums, suffix in matches5:
-        yield prefix, f'RRID:NCBITaxon_{nums.strip()}', f'{a}{b}{nums}', suffix
+        yield prefix, f'RRID:NCBITaxon_{nums.strip()}', f'{ncbi}{tax}{nums}', suffix
 
 
 # extract from post

--- a/scibot/extract.py
+++ b/scibot/extract.py
@@ -341,9 +341,9 @@ def find_rrids(text):
         yield prefix, f'RRID:SAMN{nums.strip()}', f'{a}{b}{nums}', suffix
 
     # fifth round for NCBI Taxonomy
-    regex5 = '(.{0,32})(NCBI)(((:|(:\s))?)(((t|T)(a)?x((id)|(Id)|(ID))|Taxon)(_|:)?(\s)?))([0-9]{3,8})([^\w].{0,31})'
+    regex5 = r'(.{0,32})(NCBI)(:?\s?)(taxid|Taxid|taxId|TaxId|taxID|TaxID|txid|txId|txID|Txid|TxId|TxID|Taxon|Taxonomy)(_|:)(\s?)([0-9]{3,8})([^\w].{0,31})'
     matches5 = re.findall(regex5, text)
-    for prefix, ncbi, tax, nums, suffix in matches5:
+    for prefix, ncbi, delim1, tax, delim2, delim3, nums, suffix in matches5:
         yield prefix, f'RRID:NCBITaxon_{nums.strip()}', f'{ncbi}{tax}{nums}', suffix
 
 


### PR DESCRIPTION
The following patterns will be FOUND by scibot:

NCBI, then ':' or ': ' or nothing, then taxId, txid, or Taxon (or some other capitalization related variations), then '_', ':', or nothing, and the number (length assumed from 3 to 8; that may need changing in the future)

The RRID that scibot will actually RETURN will always be of the form

RRID:NCBITaxon_12345